### PR TITLE
Dismiss terratest check for readme PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -200,8 +200,13 @@ pull_request_rules:
       - "head~=auto-update/.*"
       - "files~=\\.(md|gif|png|jpg|mp4)$"
     actions:
+      post_check:
+        # Skip terratest if the PR only updates markdown files
+        neutral_conditions:
+          - test/terratest
       review:
         type: APPROVE
+        message: Automatically approving auto readme updates
 
   - name: "merge automated PRs that only update the markdown files, images or videos"
     conditions:


### PR DESCRIPTION
## what
* Dismiss terratest check for readme PRs

## why
* Terratest status requirements block auto merge PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced automation rules for handling pull requests related to markdown files, images, or videos.
	- Automatic approval and merging of specific automated pull requests when conditions are met.
  
- **Bug Fixes**
	- Improved checks to ensure all conditions are satisfied before merging automated PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->