### PR TITLE
[terratest] Pin Atmos version 1.129.0

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -235,6 +235,7 @@ jobs:
         uses: cloudposse/github-action-setup-atmos@v2
         with:
           install-wrapper: false
+          version: 1.129.0
 
       - name: "Install Go"
         uses: actions/setup-go@v5
@@ -304,7 +305,6 @@ jobs:
       - name: "Create fixtures"
         id: fixtures
         run: |-
-          atmos version
           terraform --version
           pwd
           cd test


### PR DESCRIPTION
## what
* Pin Atmos version 1.129.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Atmos installation step to version `1.129.0`.
	- Removed the unnecessary command `atmos version` from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->