### PR TITLE
[terratest] Fix fixture state upload

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -310,7 +310,7 @@ jobs:
           cd test
           go test -v -cth.skip-tmp-dir -cth.skip-tests
           cd -
-          ls -la 
+          touch state/.artifact.keep 
 
       - name: "Save Terraform state for fixtures"
         id: upload


### PR DESCRIPTION
## what
* Fix fixture state upload if no fixtures are provisioned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `cleanup` job to manage test fixture destruction and status updates.
  
- **Improvements**
	- Enhanced the `terratest` job by adding a step to download Terraform state for fixtures.
	- Streamlined logic for updating GitHub statuses across jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->