### PR TITLE
Skip `commits verified` for README PRs merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -239,7 +239,7 @@ pull_request_rules:
       - *not_in_conflict
       - *not_wip
       - *checks_are_passing
-      - *all_commits_verified
+      # - *all_commits_verified
       - *is_approved
       - "author=cloudposse-releaser[bot]"
       - "files=README.md"


### PR DESCRIPTION
## what
* Skip `commits verified` for README PRs merge

## why
* Old README update PRs did not use sign for commits. We need this PRs get merged 

