### PR TITLE
Run tests on latest terraform

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -458,8 +458,6 @@ jobs:
       - name: "Install Terraform"
         if: ${{ matrix.platform == 'terraform' }}
         uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.7
 
       - name: "Install Atmos"
         uses: cloudposse/github-action-setup-atmos@v2

--- a/.github/workflows/shared-terratest-queue.yml
+++ b/.github/workflows/shared-terratest-queue.yml
@@ -232,8 +232,6 @@ jobs:
       - name: "Install Terraform"
         if: ${{ matrix.platform == 'terraform' }}
         uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.7
 
       - name: "Install Atmos"
         uses: cloudposse/github-action-setup-atmos@v2


### PR DESCRIPTION
## what
* Remove pin `terraform 1.5.7` for tests execution

## why
* Ensure components work with the actual Terraform version