### PR TITLE
Create atmos/terraform-component.yaml

### DIFF
--- a/.github/atmos/terraform-component.yaml
+++ b/.github/atmos/terraform-component.yaml
@@ -1,0 +1,39 @@
+docs:
+  generate:
+    readme:
+      base-dir: .
+      input:
+        - "./README.yaml"
+        - get_support: true        
+      template: "https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/README.md.gotmpl"
+      output: "./README.md"
+      terraform:
+        source: .
+        enabled: true
+        format: "markdown table"
+        show_providers: false
+        show_inputs: true
+        show_outputs: true
+        sort_by: "name"
+        hide_empty: false
+        indent_level: 2
+
+commands:
+- name: test
+  commands:
+  - name: "init"
+    description: Initialize tests
+    steps:
+      - "make -C test/src init"
+
+  - name: "run"
+    description: Run tests
+    steps:
+      - "cd test/src && go mod tidy"
+      - "cd test/src && go test -v -timeout 60m"
+
+  - name: "clean"
+    description: Clean tests
+    steps:
+      - "make -C test/src clean"
+      - "rm -rf examples/*/.terraform examples/*/.terraform.lock.hcl"


### PR DESCRIPTION
## what
* Create atmos/terraform-component.yaml

## why
* Use the atmos readme generation instead of makefiles 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduces automated generation of the Terraform component README using a standardized template, including inputs and outputs rendered in a markdown table.

* **Chores**
  * Adds test lifecycle commands (init, run, clean) to manage test setup, execution, and cleanup for the component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->