### PR TITLE
Add DD_HOST to Datadog environment variables

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -294,6 +294,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -304,6 +305,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then
@@ -500,6 +502,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -511,6 +514,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then
@@ -722,6 +726,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -733,6 +738,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then

--- a/.github/workflows/shared-terratest-queue.yml
+++ b/.github/workflows/shared-terratest-queue.yml
@@ -133,6 +133,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -143,6 +144,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then
@@ -280,6 +282,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -291,6 +294,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then
@@ -413,6 +417,7 @@ jobs:
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_HOST: ${{ secrets.DD_HOST }}
           SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
           SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -424,6 +429,7 @@ jobs:
           if [[ "$USES_DATADOG" == "true" ]]; then
             printf "%s=%s\n"  DD_API_KEY "$DD_API_KEY" >> "$GITHUB_ENV"
             printf "%s=%s\n"  DD_APP_KEY "$DD_APP_KEY" >> "$GITHUB_ENV"
+            printf "%s=%s\n"  DD_HOST "$DD_HOST" >> "$GITHUB_ENV"
             echo exported Datadog
           fi
           if [[ "$USES_GITHUB" == "true" ]]; then


### PR DESCRIPTION
## what
* Added DD_HOST environment variable for Datadog.

## why
* To run the Datadog-related components tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflows to include a new monitoring host secret, ensuring it’s injected into the environment where monitoring is enabled.
  - Standardized environment propagation across relevant jobs so the monitoring context is consistently available during pipeline runs.
  - Improves reliability of monitoring-related flows in Terraform/CI without impacting user-facing features.
  - No changes to public APIs or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->